### PR TITLE
Add GPT-2 backspace example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install torch==2.2.2+cpu -f https://download.pytorch.org/whl/torch_stable.ht
 pip install transformers datasets
 ```
 
-Run training (this uses the tiny example data in `data/train.txt`):
+Run training (the script downloads the `wikitext-2-raw-v1` dataset from HuggingFace):
 
 ```bash
 python src/train.py

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # BacktrackLM
+
+This repository demonstrates a simple language model based on GPT-2 that can use a special `<|backspace|>` token to delete previously generated tokens. It also supports moving a text cursor during generation so the model can insert or remove text in place.
+
+## Training
+
+Install the required packages:
+
+```bash
+pip install torch==2.2.2+cpu -f https://download.pytorch.org/whl/torch_stable.html
+pip install transformers datasets
+```
+
+Run training (this uses the tiny example data in `data/train.txt`):
+
+```bash
+python src/train.py
+```
+
+The trained model and tokenizer will be saved to the `model` directory.
+
+## Inference
+
+Use `src/inference.py` to generate text. The script implements a small decoding loop that interprets the following special tokens:
+
+- `<|backspace|>` – delete the character before the cursor
+- `<|cursor_left_1|>` / `<|cursor_right_1|>` – move the cursor left or right by one character
+- `<|cursor_left_10|>` / `<|cursor_right_10|>` – move ten characters
+- `<|cursor_left_100|>` / `<|cursor_right_100|>` – move one hundred characters
+- `<|cursor_left_1000|>` / `<|cursor_right_1000|>` – move one thousand characters
+
+After generation finishes the script prints both the raw tokens and the final edited text.
+
+```bash
+python src/inference.py
+```
+
+## Dataset augmentation idea
+
+After training the base model, you can create new training pairs where a prompt is followed by a partially incorrect answer that the model must fix using `<|backspace|>` tokens. This encourages the model to edit its own outputs during generation.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip install torch==2.2.2+cpu -f https://download.pytorch.org/whl/torch_stable.ht
 pip install transformers datasets
 ```
 
-Run training (the script downloads the `wikitext-2-raw-v1` dataset from HuggingFace):
+Run training (the script downloads the `wikitext-2-raw-v1` dataset from HuggingFace and automatically creates a mix of normal and correction samples):
 
 ```bash
 python src/train.py
@@ -35,6 +35,6 @@ After generation finishes the script prints both the raw tokens and the final ed
 python src/inference.py
 ```
 
-## Dataset augmentation idea
+## Dataset composition
 
-After training the base model, you can create new training pairs where a prompt is followed by a partially incorrect answer that the model must fix using `<|backspace|>` tokens. This encourages the model to edit its own outputs during generation.
+During preprocessing, 75% of the training examples are kept as-is while the remaining 25% are turned into correction tasks. For a correction task a random line from the dataset is treated as an incorrect answer and then deleted with enough `<|backspace|>` tokens before inserting the correct text. This gives the model experience removing wrong output and replacing it with the right text.

--- a/data/train.txt
+++ b/data/train.txt
@@ -1,0 +1,3 @@
+The cat sat on the mat.
+The color is red <|backspace|>blue.
+I like to eat appl <|backspace|>apples.

--- a/data/train.txt
+++ b/data/train.txt
@@ -1,3 +1,0 @@
-The cat sat on the mat.
-The color is red <|backspace|>blue.
-I like to eat appl <|backspace|>apples.

--- a/src/inference.py
+++ b/src/inference.py
@@ -1,0 +1,70 @@
+import torch
+from transformers import GPT2TokenizerFast, GPT2LMHeadModel
+
+BACKSPACE_TOKEN = "<|backspace|>"
+CURSOR_TOKENS = {
+    "<|cursor_left_1|>": -1,
+    "<|cursor_right_1|>": 1,
+    "<|cursor_left_10|>": -10,
+    "<|cursor_right_10|>": 10,
+    "<|cursor_left_100|>": -100,
+    "<|cursor_right_100|>": 100,
+    "<|cursor_left_1000|>": -1000,
+    "<|cursor_right_1000|>": 1000,
+}
+
+
+def generate(text: str, model_path: str = "model", max_steps: int = 50):
+    tokenizer = GPT2TokenizerFast.from_pretrained(model_path)
+    special_tokens = [BACKSPACE_TOKEN] + list(CURSOR_TOKENS.keys())
+    missing = [t for t in special_tokens if t not in tokenizer.get_vocab()]
+    if missing:
+        tokenizer.add_special_tokens({"additional_special_tokens": missing})
+
+    model = GPT2LMHeadModel.from_pretrained(model_path)
+    model.resize_token_embeddings(len(tokenizer))
+
+    token_ids = {tok: tokenizer.convert_tokens_to_ids(tok) for tok in special_tokens}
+
+    input_ids = tokenizer.encode(text, return_tensors="pt")
+    generated = input_ids[0].tolist()
+
+    out_text = tokenizer.decode(input_ids[0], skip_special_tokens=True)
+    cursor = len(out_text)
+
+    for _ in range(max_steps):
+        with torch.no_grad():
+            logits = model(torch.tensor([generated])).logits[0, -1]
+        next_token_id = int(torch.argmax(logits))
+        generated.append(next_token_id)
+
+        if next_token_id == token_ids[BACKSPACE_TOKEN]:
+            if cursor > 0:
+                out_text = out_text[: cursor - 1] + out_text[cursor:]
+                cursor -= 1
+            continue
+
+        move = None
+        for tok, offset in CURSOR_TOKENS.items():
+            if next_token_id == token_ids.get(tok):
+                move = offset
+                break
+        if move is not None:
+            cursor = max(0, min(len(out_text), cursor + move))
+            continue
+
+        token_str = tokenizer.decode([next_token_id], clean_up_tokenization_spaces=False)
+        out_text = out_text[:cursor] + token_str + out_text[cursor:]
+        cursor += len(token_str)
+
+        if next_token_id == tokenizer.eos_token_id:
+            break
+
+    raw = tokenizer.decode(generated, skip_special_tokens=True)
+    return raw, out_text
+
+if __name__ == '__main__':
+    text = input('Prompt: ')
+    raw, corrected = generate(text)
+    print('Raw output:', raw)
+    print('Corrected:', corrected)

--- a/src/train.py
+++ b/src/train.py
@@ -1,6 +1,7 @@
 import os
+import random
 from pathlib import Path
-from datasets import load_dataset
+from datasets import Dataset, load_dataset
 from transformers import (
     GPT2TokenizerFast,
     GPT2LMHeadModel,
@@ -23,14 +24,27 @@ CURSOR_TOKENS = {
 
 def main():
     dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
-    tokenizer = GPT2TokenizerFast.from_pretrained('gpt2')
+    tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
     special_tokens = [BACKSPACE_TOKEN] + list(CURSOR_TOKENS.keys())
     to_add = [t for t in special_tokens if t not in tokenizer.get_vocab()]
     if to_add:
-        tokenizer.add_special_tokens({'additional_special_tokens': to_add})
+        tokenizer.add_special_tokens({"additional_special_tokens": to_add})
     tokenizer.pad_token = tokenizer.eos_token
-    model = GPT2LMHeadModel.from_pretrained('gpt2')
+    model = GPT2LMHeadModel.from_pretrained("gpt2")
     model.resize_token_embeddings(len(tokenizer))
+
+    # Build a mixed dataset of normal and correction samples
+    raw_texts = [t.strip() for t in dataset["text"] if t.strip()]
+    augmented = []
+    for text in raw_texts:
+        if random.random() < 0.75:
+            augmented.append(text)
+        else:
+            wrong = random.choice(raw_texts)
+            wrong_tokens = tokenizer.encode(wrong)
+            edits = " ".join([BACKSPACE_TOKEN] * len(wrong_tokens))
+            augmented.append(f"{wrong} {edits} {text}")
+    dataset = Dataset.from_dict({"text": augmented})
 
     def tokenize(example):
         return tokenizer(example['text'], truncation=True)

--- a/src/train.py
+++ b/src/train.py
@@ -1,7 +1,13 @@
 import os
 from pathlib import Path
 from datasets import load_dataset
-from transformers import GPT2TokenizerFast, GPT2LMHeadModel, Trainer, TrainingArguments, DataCollatorForLanguageModeling
+from transformers import (
+    GPT2TokenizerFast,
+    GPT2LMHeadModel,
+    Trainer,
+    TrainingArguments,
+    DataCollatorForLanguageModeling,
+)
 
 BACKSPACE_TOKEN = "<|backspace|>"
 CURSOR_TOKENS = {
@@ -15,18 +21,8 @@ CURSOR_TOKENS = {
     "<|cursor_right_1000|>": 1000,
 }
 
-def load_data(file_path):
-    data = []
-    with open(file_path, 'r', encoding='utf-8') as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                data.append({'text': line})
-    return {'train': data}
-
-
 def main():
-    data = load_data('data/train.txt')
+    dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
     tokenizer = GPT2TokenizerFast.from_pretrained('gpt2')
     special_tokens = [BACKSPACE_TOKEN] + list(CURSOR_TOKENS.keys())
     to_add = [t for t in special_tokens if t not in tokenizer.get_vocab()]
@@ -39,10 +35,7 @@ def main():
     def tokenize(example):
         return tokenizer(example['text'], truncation=True)
 
-    # Convert to Dataset object
-    from datasets import Dataset
-    dataset = Dataset.from_list(data['train'])
-    dataset = dataset.map(tokenize, batched=False)
+    dataset = dataset.map(tokenize, batched=True)
 
     data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
 

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,83 @@
+import os
+from pathlib import Path
+from datasets import load_dataset
+from transformers import GPT2TokenizerFast, GPT2LMHeadModel, Trainer, TrainingArguments, DataCollatorForLanguageModeling
+
+BACKSPACE_TOKEN = "<|backspace|>"
+CURSOR_TOKENS = {
+    "<|cursor_left_1|>": -1,
+    "<|cursor_right_1|>": 1,
+    "<|cursor_left_10|>": -10,
+    "<|cursor_right_10|>": 10,
+    "<|cursor_left_100|>": -100,
+    "<|cursor_right_100|>": 100,
+    "<|cursor_left_1000|>": -1000,
+    "<|cursor_right_1000|>": 1000,
+}
+
+def load_data(file_path):
+    data = []
+    with open(file_path, 'r', encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                data.append({'text': line})
+    return {'train': data}
+
+
+def main():
+    data = load_data('data/train.txt')
+    tokenizer = GPT2TokenizerFast.from_pretrained('gpt2')
+    special_tokens = [BACKSPACE_TOKEN] + list(CURSOR_TOKENS.keys())
+    to_add = [t for t in special_tokens if t not in tokenizer.get_vocab()]
+    if to_add:
+        tokenizer.add_special_tokens({'additional_special_tokens': to_add})
+    tokenizer.pad_token = tokenizer.eos_token
+    model = GPT2LMHeadModel.from_pretrained('gpt2')
+    model.resize_token_embeddings(len(tokenizer))
+
+    def tokenize(example):
+        return tokenizer(example['text'], truncation=True)
+
+    # Convert to Dataset object
+    from datasets import Dataset
+    dataset = Dataset.from_list(data['train'])
+    dataset = dataset.map(tokenize, batched=False)
+
+    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+    training_args = TrainingArguments(
+        output_dir='model',
+        overwrite_output_dir=True,
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        logging_steps=1,
+        save_strategy="no",
+        learning_rate=5e-5,
+        weight_decay=0.01,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dataset,
+        data_collator=data_collator,
+    )
+
+    trainer.train()
+    try:
+        from torch.distributed.tensor import DTensor  # type: ignore
+    except Exception:
+        import torch
+        import importlib
+        tdt = importlib.import_module('torch.distributed.tensor')
+        if not hasattr(tdt, 'DTensor'):
+            tdt.DTensor = type('DTensor', (torch.Tensor,), {})
+        import transformers.modeling_utils as mu
+        mu.DTensor = tdt.DTensor
+
+    model.save_pretrained('model', safe_serialization=True)
+    tokenizer.save_pretrained('model')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement a tiny training script for a GPT-2 LM that understands a `<|backspace|>` token
- add simple inference script applying the backspace edits
- provide a minimal dataset and usage instructions
- extend tokenizer and inference to handle cursor movement tokens
- implement custom generation loop with cursor editing

## Testing
- `python src/train.py` *(fails: ModuleNotFoundError: No module named 'datasets')*
- `python src/inference.py <<EOF
The color is red
EOF` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_684c9fd0fcfc832da92e101b8c074d2a